### PR TITLE
TST: add Continuous Integration and fix bug due to the Kaggle API trying to read the secret file at import time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: ml
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e src/
+          pip install -r requirements-dev.txt
+      # - name: Lint with flake8
+      #   run: |
+      #     # stop the build if there are Python syntax errors or undefined names
+      #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+      #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          pytest

--- a/src/ml/io.py
+++ b/src/ml/io.py
@@ -1,15 +1,22 @@
 from pathlib import Path
+from typing import Protocol, Type
 
-from kaggle import api
 from loguru import logger
 
 
-def download_comp_data(comp_name: str, path: Path, api=api) -> Path:
+class KaggleAPITemplate(Protocol):
+    def competition_download_cli(self, competition, path) -> None:
+        pass
+
+
+def download_comp_data(
+    comp_name: str, path: Path, api=Type[KaggleAPITemplate]
+) -> Path:
     """Download competition data from Kaggle, and save it to `path`
     destination.
 
     Args:
-        api: API client.
+        api: Kaggle API client.
         comp_name: Short name of Kaggle competition.
         path: Destination.
     """

--- a/src/tests/test_io.py
+++ b/src/tests/test_io.py
@@ -1,12 +1,10 @@
 import zipfile
 from pathlib import Path
 
-from kaggle.api import KaggleApi
-
 from ml.io import download_comp_data, extract_comp_data
 
 
-class FakeKaggleAPI(KaggleApi):
+class KaggleAPIFake:
     def __init__(self) -> None:
         pass
 
@@ -16,7 +14,7 @@ class FakeKaggleAPI(KaggleApi):
 
 def test_download_from_kaggle():
     result: Path = download_comp_data(
-        api=FakeKaggleAPI(), comp_name="test", path=Path("tmp")
+        api=KaggleAPIFake(), comp_name="test", path=Path("tmp")
     )
     assert result == Path("tmp/test.zip")
 


### PR DESCRIPTION
Set up CI for this repo. 

In addition, we changed the type hint on a function that required injecting the Kaggle API client. The problem was that at import time, the Kaggle API also was trying to look for the secret key file, which we don't have in the CI environment. To address that, we started using Python's [`Protocol`](https://peps.python.org/pep-0544/) for structural subtyping. In this way, we can use "static duck typing" and let `Protocol` and `mypy` ensure `KaggleAPIFake` behaves like `KaggleAPI` for those functionalities we need.