### PR TITLE
MAINT: refactor recipe to train generic ML model

### DIFF
--- a/blazingai/io.py
+++ b/blazingai/io.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import numpy as np
+from blazingai.metrics import CrossValMetrics
 from numpy.typing import ArrayLike
 
 
@@ -10,16 +11,10 @@ def save_pred(fpath: Path, pred: ArrayLike) -> None:
     np.save(fpath, pred)
 
 
-def save_metrics(
-    fpath: Path,
-    metric: str,
-    trn_metric: float,
-    val_metric: float,
-    oof_metric: float,
-) -> None:
+def save_mtrc(fpath: Path, metrics: CrossValMetrics) -> None:
     data = {}
-    data[f"train {metric}"] = round(trn_metric, 4)
-    data[f"cv {metric}"] = round(val_metric, 4)
-    data[f"oof {metric}"] = round(oof_metric, 4)
+    data[f"train {metrics.metric}"] = round(metrics.trn_metric, 4)
+    data[f"cv {metrics.metric}"] = round(metrics.val_metric, 4)
+    data[f"oof {metrics.metric}"] = round(metrics.oof_metric, 4)
     with open(fpath, "w") as f:
         json.dump(data, f)

--- a/blazingai/learner.py
+++ b/blazingai/learner.py
@@ -1,8 +1,8 @@
 from typing import Any, List, Optional
 
-import pytorch_lightning as pl
+import lightning as pl
 import timm
-from omegaconf import OmegaConf
+from omegaconf import DictConfig
 from torch import nn
 
 from .loss import loss_factory
@@ -15,7 +15,7 @@ class ImageClassifier(pl.LightningModule):
         self,
         in_channels: int,
         num_classes: int,
-        cfg: OmegaConf,
+        cfg: DictConfig,
         pretrained: bool = False,
     ) -> None:
         super().__init__()
@@ -100,9 +100,7 @@ class ImageClassifier(pl.LightningModule):
         return loss, target, preds.sigmoid()
 
     def configure_optimizers(self):
-        optimizer = optimizer_factory(
-            params=self.parameters(), hparams=self.hparams
-        )
+        optimizer = optimizer_factory(params=self.parameters(), hparams=self.hparams)
 
         scheduler = lr_scheduler_factory(
             optimizer=optimizer,
@@ -136,9 +134,7 @@ class ImageClassifier(pl.LightningModule):
         try:
             train_metric = self.trainer.callback_metrics["train_metric"]
             val_metric = self.trainer.callback_metrics["val_metric"]
-            if self.best_val_metric is None or self._is_metric_better(
-                val_metric
-            ):
+            if self.best_val_metric is None or self._is_metric_better(val_metric):
                 self.best_val_metric = val_metric
                 self.best_train_metric = train_metric
         except (KeyError, AttributeError):

--- a/blazingai/metrics.py
+++ b/blazingai/metrics.py
@@ -1,13 +1,50 @@
 from typing import Any, Callable, Optional
 
+import numpy as np
 import torch
 import torchmetrics
+from omegaconf import DictConfig
 from torch import Tensor
 from torchmetrics.functional.regression.mse import mean_squared_error
 from torchmetrics.metric import Metric
 
 
-def metric_factory(cfg):
+def compute_oof_metric(cfg: DictConfig, y_true, y_pred) -> float:
+    metric = metric_factory(cfg=cfg)
+    y_pred = torch.tensor(y_pred)
+    y_true = torch.tensor(y_true)
+    return metric(y_pred, y_true)
+
+
+class CrossValMetrics:
+    def __init__(self, cfg: DictConfig) -> None:
+        self.cfg = cfg
+        self.metric = cfg.metric
+        self._trgt = []
+        self._pred = []
+        self._val_scores = []
+        self._trn_scores = []
+
+    @property
+    def trn_metric(self):
+        return np.mean(self._trn_scores)
+
+    @property
+    def val_metric(self):
+        return np.mean(self._val_scores)
+
+    @property
+    def oof_metric(self):
+        return compute_oof_metric(cfg=self.cfg, y_pred=self._pred, y_true=self._trgt)
+
+    def add(self, trgt, pred, val_score, trn_score):
+        self._trgt.extend(trgt)
+        self._pred.extend(pred)
+        self._val_scores.append(val_score)
+        self._trn_scores.append(trn_score)
+
+
+def metric_factory(cfg: DictConfig):
     if cfg.metric == "auc":
         # return torchmetrics.AUROC(pos_label=1)
         return torchmetrics.AUROC(

--- a/blazingai/params.py
+++ b/blazingai/params.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
+from lightning.pytorch.core.saving import load_hparams_from_yaml
 from omegaconf import DictConfig
 from omegaconf.errors import ConfigAttributeError
-from pytorch_lightning.core.saving import load_hparams_from_yaml
 
 
 def load_cfg(fpath: Path, cfg_name: str) -> DictConfig:

--- a/blazingai/vision/data.py
+++ b/blazingai/vision/data.py
@@ -2,8 +2,9 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import lightning as pl
+
 import numpy as np
-import pytorch_lightning as pl
 import torch
 from PIL import Image, ImageFile
 from scipy.ndimage import zoom

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ pylibjpeg-libjpeg = "^1.3.2"
 pylibjpeg-openjpeg = "^1.2.1"
 
 [tool.black]
-line-length = 79
+# line-length = 79
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,16 +1,23 @@
 import numpy as np
-from blazingai.io import save_metrics, save_pred
+import pytest
+from blazingai.io import save_mtrc, save_pred
 
 
-def test_save_metrics(tmp_path):
+class CrossValMetricsFake:
+    metric = "rmse"
+    trn_metric = 0.1
+    val_metric = 0.05
+    oof_metric = 0.07
+
+
+@pytest.fixture
+def metric():
+    return CrossValMetricsFake()
+
+
+def test_save_metrics(tmp_path, metric):
     fpath = tmp_path / "model_one.score"
-    save_metrics(
-        fpath=fpath,
-        metric="rmse",
-        trn_metric=0.10,
-        val_metric=0.05,
-        oof_metric=0.07,
-    )
+    save_mtrc(fpath=fpath, metrics=metric)
     with open(fpath) as f:
         assert f.readline() == '{"train rmse": 0.1, "cv rmse": 0.05, "oof rmse": 0.07}'
 


### PR DESCRIPTION
Lots of changes, including:

* Abstracting generic training loop that any ML task could use
* Use `DictConfig` as a type hint for `OmegaConf` objects to avoid `mypy` and `pyright` warnings
* Created `CrossValMetrics` to abstract away the logic to store and update cross-validation metrics
* Renamed some variables here and there